### PR TITLE
Refactor device info and datalogging capabilities

### DIFF
--- a/scrutiny/cli/commands/runtest.py
+++ b/scrutiny/cli/commands/runtest.py
@@ -52,7 +52,7 @@ class RunTest(BaseCommand):
         logging_level_str = self.requested_log_level if self.requested_log_level else "critical"
         logging_level = getattr(logging, logging_level_str.upper())
         if logging_level == logging.DEBUG:
-            format_string += "%(relativeCreated)0.3f "
+            format_string += "%(relativeCreated)0.3f (#%(thread)d)"
         format_string += '[%(levelname)s] <%(name)s> %(message)s'
         logging.getLogger().handlers[0].setFormatter(logging.Formatter(format_string))
         logging.getLogger().setLevel(logging_level)

--- a/scrutiny/gui/core/server_manager.py
+++ b/scrutiny/gui/core/server_manager.py
@@ -279,7 +279,7 @@ class ServerManager:
 
                     try:
                         self._client.wait_server_status_update(0.2)
-                        self._fsm_data.server_info = self._client.get_server_status()
+                        self._fsm_data.server_info = self._client.get_latest_server_status()
                         self.signals.status_received.emit()
                     except sdk.exceptions.TimeoutException:
                         pass
@@ -526,7 +526,7 @@ class ServerManager:
     
     def get_server_info(self) -> Optional[sdk.ServerInfo]:
         try:
-            return self._client.get_server_status()
+            return self._client.get_latest_server_status()
         except sdk.exceptions.ScrutinySDKException:
             return None
     

--- a/scrutiny/gui/widgets/status_bar.py
+++ b/scrutiny/gui/widgets/status_bar.py
@@ -301,10 +301,10 @@ class StatusBar(QStatusBar):
 
     def _device_about_func(self) -> None:
         server_info = self._server_manager.get_server_info()
-        if server_info is not None:
-            if server_info.device is not None:
-                self._device_info_dialog.rebuild(server_info.device)
-                self._device_info_dialog.show()
+        #if server_info is not None:
+            #if server_info.device is not None:
+            #    self._device_info_dialog.rebuild(server_info.device)
+            #    self._device_info_dialog.show()
 
     def _device_config_applied(self, dialog:DeviceConfigDialog) -> None:
         # When the user click OK in the DeviceLinkConfigDialog. He wants the change the link between the server and the device

--- a/scrutiny/sdk/datalogging.py
+++ b/scrutiny/sdk/datalogging.py
@@ -7,6 +7,7 @@
 #   Copyright (c) 2021 Scrutiny Debugger
 
 from scrutiny import sdk
+from scrutiny.sdk.definitions import *
 from scrutiny.core.datalogging import *
 from scrutiny.core import validation
 from dataclasses import dataclass
@@ -23,67 +24,13 @@ if TYPE_CHECKING:
     from scrutiny.sdk.client import ScrutinyClient
 
 
-class DataloggingEncoding(enum.Enum):
-    """(Enum) Defines the data format used to store the samples in the datalogging buffer"""
-    RAW = 1
-
-
-@dataclass(frozen=True, init=False)
-class SamplingRate:
-    """(Immutable struct) Represent a sampling rate supported by the device"""
-
-    identifier: int
-    """The unique identifier of the sampling rate. Matches the embedded device index in the loop array set in the configuration"""
-
-    name: str
-    """Name for display"""
-
-
-@dataclass(frozen=True)
-class FixedFreqSamplingRate(SamplingRate):
-    """(Immutable struct) Represent a fixed frequency sampling rate supported by the device"""
-
-    frequency: float
-    """The sampling rate frequency"""
-
-    def __post_init__(self) -> None:
-        validation.assert_type(self.identifier, 'identifier', int)
-        validation.assert_type(self.name, 'name', str)
-        validation.assert_type(self.frequency, 'frequency', float)
-
-
-@dataclass(frozen=True)
-class VariableFreqSamplingRate(SamplingRate):
-    """(Immutable struct) Represent a variable frequency sampling rate supported by the device. Has no known frequency"""
-
-    def __post_init__(self) -> None:
-        validation.assert_type(self.identifier, 'identifier', int)
-        validation.assert_type(self.name, 'name', str)
-
-
-@dataclass(frozen=True)
-class DataloggingCapabilities:
-    """(Immutable struct) Tells what the device is able to achieve in terms of datalogging"""
-
-    encoding: DataloggingEncoding
-    """The encoding of data"""
-
-    buffer_size: int
-    """Size of the datalogging buffer"""
-
-    max_nb_signal: int
-    """Maximum number of signal per acquisition (including time if measured)"""
-
-    sampling_rates: List[SamplingRate]
-    """List of available sampling rates"""
-
-    def __post_init__(self) -> None:
-        validation.assert_type(self.encoding, 'encoding', DataloggingEncoding)
-        validation.assert_type(self.buffer_size, 'buffer_size', int)
-        validation.assert_type(self.max_nb_signal, 'max_nb_signal', int)
-        validation.assert_type(self.sampling_rates, 'sampling_rates', list)
-        for i in range(len(self.sampling_rates)):
-            validation.assert_type(self.sampling_rates[i], f'sampling_rates[{i}]', SamplingRate)
+__all__ = [
+    'XAxisType',
+    'TriggerCondition',
+    'DataloggingConfig',
+    'DataloggingRequest',
+    'DataloggingStorageEntry'
+]
 
 
 class XAxisType(enum.Enum):
@@ -173,7 +120,7 @@ class DataloggingConfig:
 
         :param sampling_rate: The acquisition sampling rate. Can be the sampling rate ID in the device or an instance 
             of :class:`SamplingRate<scrutiny.sdk.datalogging.SamplingRate>` gotten from the :class:`DataloggingCapabilities<scrutiny.sdk.datalogging.DataloggingCapabilities>` 
-            returned by :meth:`ScrutinyClient.get_datalogging_capabilities<scrutiny.sdk.client.ScrutinyClient.get_datalogging_capabilities>` 
+            returned by :meth:`ScrutinyClient.get_device_info<scrutiny.sdk.client.ScrutinyClient.get_device_info>` 
         :param decimation: The decimation factor that reduces the effective sampling rate
         :param timeout: Timeout to the acquisition. After the datalogger is armed, it will forcefully trigger after this amount of time. 0 means no timeout
         :param name: Name of the configuration. Save into the database for reference

--- a/scrutiny/sdk/docs/source/datalogging.rst
+++ b/scrutiny/sdk/docs/source/datalogging.rst
@@ -26,10 +26,8 @@ The first step before configuring the datalogger is knowing what the device is c
 - How many signal can I log?
 - etc
 
-This information can be obtained using the :meth:`ScrutinyClient.get_datalogging_capabilities<scrutiny.sdk.client.ScrutinyClient.get_datalogging_capabilities>` method, 
-which returns a :class:`DataloggingCapabilities<scrutiny.sdk.datalogging.DataloggingCapabilities>` object.
-
-.. automethod:: scrutiny.sdk.client.ScrutinyClient.get_datalogging_capabilities
+This information can be obtained using the :meth:`ScrutinyClient.get_device_info<scrutiny.sdk.client.ScrutinyClient.get_device_info>` method, 
+which returns a :class:`DeviceInfo<scrutiny.sdk.DeviceInfo>` object with attribute :attr:`datalogging_capabilities<scrutiny.sdk.DeviceInfo.datalogging_capabilities>`
 
 -----
 

--- a/scrutiny/sdk/docs/source/server_control.rst
+++ b/scrutiny/sdk/docs/source/server_control.rst
@@ -43,11 +43,15 @@ It includes:
 
 -----
 
-.. automethod:: scrutiny.sdk.client.ScrutinyClient.get_server_status
+.. automethod:: scrutiny.sdk.client.ScrutinyClient.get_latest_server_status
 
 -----
 
 .. automethod:: scrutiny.sdk.client.ScrutinyClient.wait_server_status_update
+
+-----
+
+.. automethod:: scrutiny.sdk.client.ScrutinyClient.request_server_status_update
 
 -----
 

--- a/scrutiny/sdk/watchable_handle.py
+++ b/scrutiny/sdk/watchable_handle.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 ValType = Union[int, float, bool]
 
+__all__ = ['WatchableHandle']
 
 class WatchableHandle:
     """A handle to a server watchable element (Variable / Alias / RuntimePublishedValue) that gets updated by the client thread."""

--- a/scrutiny/server/api/typing.py
+++ b/scrutiny/server/api/typing.py
@@ -70,6 +70,19 @@ class WatchableListContent(TypedDict):
     rpv: List[DatastoreEntryDefinitionNoType]
 
 
+class SamplingRate(TypedDict):
+    type: Literal['fixed_freq', 'variable_freq']
+    name: str
+    frequency: Optional[float]
+    identifier: int
+
+
+class DataloggingCapabilities(TypedDict):
+    encoding: Literal['raw']
+    buffer_size: int
+    max_nb_signal: int
+    sampling_rates: List[SamplingRate]
+
 class DeviceInfo(TypedDict):
     device_id: str
     display_name: str
@@ -84,6 +97,7 @@ class DeviceInfo(TypedDict):
     supported_feature_map: Dict[SupportedFeature, bool]
     forbidden_memory_regions: List[Dict[Literal['start', 'size', 'end'], int]]
     readonly_memory_regions: List[Dict[Literal['start', 'size', 'end'], int]]
+    datalogging_capabilities:Optional[DataloggingCapabilities]
 
 
 class SFDEntry(TypedDict):
@@ -119,11 +133,6 @@ class DataloggingOperand(TypedDict):
     value: Union[float, str]
 
 
-class SamplingRate(TypedDict):
-    type: Literal['fixed_freq', 'variable_freq']
-    name: str
-    frequency: Optional[float]
-    identifier: int
 
 
 class SupportedCondition(TypedDict):
@@ -167,13 +176,6 @@ class DataloggingSignalDataWithAxis(DataloggingSignalData):
     axis_id: int
 
 
-class DataloggingCapabilities(TypedDict):
-    encoding: Literal['raw']
-    buffer_size: int
-    max_nb_signal: int
-    sampling_rates: List[SamplingRate]
-
-
 class AxisNameUpdateEntry(TypedDict):
     id: int
     name: str
@@ -200,6 +202,9 @@ class C2S:
     class GetServerStatus(BaseC2SMessage):
         pass
 
+    class GetDeviceInfo(BaseC2SMessage):
+        pass
+
     class GetWatchableCount(BaseC2SMessage):
         pass
 
@@ -222,8 +227,6 @@ class C2S:
     class WriteValue(BaseC2SMessage):
         updates: List[UpdateRecord]
 
-    class GetDataloggingCapabilities(BaseC2SMessage):
-        pass
 
     class RequestDataloggingAcquisition(BaseC2SMessage):
         name: Optional[str]
@@ -290,9 +293,12 @@ class S2C:
         device_status: DeviceCommStatus
         device_session_id: Optional[str]
         device_datalogging_status: DataloggingStatus
-        device_info: Optional[DeviceInfo]
         loaded_sfd: Optional[SFDEntry]
         device_comm_link: DeviceCommLinkDef   # Dict is Any,Any.  Should be EmptyDict.
+
+    class GetDeviceInfo(BaseS2CMessage):
+        available: bool
+        device_info: Optional[DeviceInfo]
 
     class GetWatchableCount(BaseS2CMessage):
         qty: WatchableCount
@@ -323,10 +329,6 @@ class S2C:
         success: bool
         request_token: str
         timestamp: float
-
-    class GetDataloggingCapabilities(BaseS2CMessage):
-        available: bool
-        capabilities: Optional[DataloggingCapabilities]
 
     class RequestDataloggingAcquisition(BaseS2CMessage):
         request_token: str
@@ -388,6 +390,7 @@ C2SMessage = Union[
     C2S.GetInstalledSFD,
     C2S.GetLoadedSFD,
     C2S.GetServerStatus,
+    C2S.GetDeviceInfo,
     C2S.GetWatchableCount,
     C2S.GetWatchableList,
     C2S.LoadSFD,
@@ -395,7 +398,6 @@ C2SMessage = Union[
     C2S.UnsubscribeWatchable,
     C2S.GetPossibleLinkConfig,
     C2S.WriteValue,
-    C2S.GetDataloggingCapabilities,
     C2S.RequestDataloggingAcquisition,
     C2S.ReadDataloggingAcquisitionContent,
     C2S.ListDataloggingAcquisitions,
@@ -413,6 +415,7 @@ S2CMessage = Union[
     S2C.GetInstalledSFD,
     S2C.GetLoadedSFD,
     S2C.InformServerStatus,
+    S2C.GetDeviceInfo,
     S2C.GetWatchableCount,
     S2C.GetWatchableList,
     S2C.SubscribeWatchable,
@@ -421,7 +424,6 @@ S2CMessage = Union[
     S2C.GetPossibleLinkConfig,
     S2C.WriteValue,
     S2C.WriteCompletion,
-    S2C.GetDataloggingCapabilities,
     S2C.RequestDataloggingAcquisition,
     S2C.InformDataloggingListChanged,
     S2C.ListDataloggingAcquisition,

--- a/scrutiny/server/datalogging/datalogging_manager.py
+++ b/scrutiny/server/datalogging/datalogging_manager.py
@@ -494,7 +494,10 @@ class DataloggingManager:
 
     def get_device_setup(self) -> Optional[device_datalogging.DataloggingSetup]:
         """Reads the datalogging configuration gotten from the device. May not be available"""
-        return self.device_handler.get_datalogging_setup()
+        device_info = self.device_handler.get_device_info()
+        if device_info is None:
+            return None
+        return device_info.datalogging_setup
 
     def get_sampling_rate(self, identifier: int) -> api_datalogging.SamplingRate:
         """Get the sampling rate identified by the given identifier. The identifier is known to the device."""

--- a/scrutiny/server/device/device_handler.py
+++ b/scrutiny/server/device/device_handler.py
@@ -297,8 +297,12 @@ class DeviceHandler:
         return self.datalogging_poller.get_datalogger_state()
 
     def get_datalogging_setup(self) -> Optional[device_datalogging.DataloggingSetup]:
-        """Get the device datalogging configuration (encoding, buffer size, etc)"""
-        return self.datalogging_poller.get_device_setup()
+        """Get the device datalogging configuration (encoding, buffer size, etc). Shortcut to avoid reading the device_info struct all the time"""
+        if self.device_info is None:
+            return None
+        if self.device_info.datalogging_setup is None:
+            return None
+        return copy.copy(self.device_info.datalogging_setup) 
 
     def get_datalogging_acquisition_completion_ratio(self) -> Optional[float]:
         """Returns a value between 0 and 1 indicating how far the acquisition is frm being completed once the trigger event has been launched"""
@@ -753,8 +757,10 @@ class DeviceHandler:
                 assert self.device_info is not None
                 assert self.device_info.supported_feature_map is not None
                 if self.device_info.supported_feature_map['datalogging']:
+                    assert self.device_info.datalogging_setup is not None
                     self.logger.debug("Enabling datalogging handling")
                     self.datalogging_poller.enable()
+                    self.datalogging_poller.configure_datalogging_setup(self.device_info.datalogging_setup)
                     self.datalogging_poller.start()
                 else:
                     self.logger.debug("Disabling datalogging handling")

--- a/test/gui/fake_sdk_client.py
+++ b/test/gui/fake_sdk_client.py
@@ -84,7 +84,7 @@ class FakeSDKClient:
     def wait_server_status_update(self, timeout=None):
         pass
 
-    def get_server_status(self) -> Optional[sdk.ServerInfo]:
+    def get_latest_server_status(self) -> Optional[sdk.ServerInfo]:
         if self.server_info is None:
             return None
         

--- a/test/integration/integration_test.py
+++ b/test/integration/integration_test.py
@@ -71,7 +71,7 @@ class ScrutinyIntegrationTest(ScrutinyUnitTest):
             self.api_conn.open()    # Client
             cast(DummyClientHandler, self.server.api.get_client_handler()).set_connections([self.api_conn])
 
-            self.wait_for_device_ready(timeout=2)
+            self.wait_for_device_ready(timeout=3)
 
             self.temp_storage_handler = SFDStorage.use_temp_folder()
 
@@ -111,24 +111,25 @@ class ScrutinyIntegrationTest(ScrutinyUnitTest):
             self.assertEqual(entry.aliasdef.offset, offset)
 
     def wait_for_device_ready(self, timeout):
-        t1 = time.time()
+        t1 = time.monotonic()
         self.server.process()
         timed_out = False
         while self.server.device_handler.get_connection_status() != DeviceHandler.ConnectionStatus.CONNECTED_READY:
-            if time.time() - t1 >= timeout:
+            if time.monotonic() - t1 >= timeout:
                 timed_out = True
                 break
             self.server.process()
+            self.emulated_device.wake_if_sleep()
             time.sleep(0.01)
 
         if timed_out:
             raise TimeoutError("Timed out while initializing emulated device")
 
     def wait_for_response(self, timeout=0.4):
-        t1 = time.time()
+        t1 = time.monotonic()
         self.server.process()
         while not self.api_conn.from_server_available():
-            if time.time() - t1 >= timeout:
+            if time.monotonic() - t1 >= timeout:
                 break
             self.server.process()
             time.sleep(0.01)
@@ -136,17 +137,17 @@ class ScrutinyIntegrationTest(ScrutinyUnitTest):
         return self.api_conn.read_from_server()
 
     def wait_for(self, timeout):
-        t1 = time.time()
+        t1 = time.monotonic()
         self.server.process()
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.server.process()
             time.sleep(0.01)
 
     def wait_true(self, func, timeout):
-        t1 = time.time()
+        t1 = time.monotonic()
         self.server.process()
         result = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.server.process()
             result = func()
             if result:
@@ -163,9 +164,9 @@ class ScrutinyIntegrationTest(ScrutinyUnitTest):
             self.server.process()
 
     def spinwait_for(self, timeout):
-        t1 = time.time()
+        t1 = time.monotonic()
         self.server.process()
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.server.process()
 
     def wait_and_load_response(self, cmd=None, nbr=1, timeout=1, ignore_error=False):

--- a/test/integration/test_interract_with_device.py
+++ b/test/integration/test_interract_with_device.py
@@ -28,17 +28,15 @@ class TestInterractWithDevice(ScrutinyIntegrationTestWithTestSFD1):
 
         return super().setUp()
 
-    def test_read_status(self):
+    def test_read_device_info(self):
         self.send_request({
-            'cmd': API.Command.Client2Api.GET_SERVER_STATUS,
+            'cmd': API.Command.Client2Api.GET_DEVICE_INFO,
         })
-        response = self.wait_and_load_response(cmd=API.Command.Api2Client.INFORM_SERVER_STATUS)
+        response = self.wait_and_load_response(cmd=API.Command.Api2Client.GET_DEVICE_INFO)
         self.assert_no_error(response)
 
-        response = cast(api_typing.S2C.InformServerStatus, response)
-
-        self.assertEqual(response['device_status'], 'connected_ready')
-
+        self.assertEqual(response['available'], True)
+        self.assertIsNotNone(response['device_info'])
         self.assertEqual(response['device_info']['device_id'], self.emulated_device.get_firmware_id_ascii())
         self.assertEqual(response['device_info']['display_name'], self.emulated_device.display_name)
         self.assertEqual(response['device_info']['max_rx_data_size'], self.emulated_device.max_rx_data_size)
@@ -69,7 +67,18 @@ class TestInterractWithDevice(ScrutinyIntegrationTestWithTestSFD1):
         self.assertEqual(response['device_info']['forbidden_memory_regions'][1]['start'], 0x3000)
         self.assertEqual(response['device_info']['forbidden_memory_regions'][1]['size'], 0x200)
         self.assertEqual(response['device_info']['forbidden_memory_regions'][1]['end'], 0x31FF)
+    
 
+    def test_read_status(self):
+        self.send_request({
+            'cmd': API.Command.Client2Api.GET_SERVER_STATUS,
+        })
+        response = self.wait_and_load_response(cmd=API.Command.Api2Client.INFORM_SERVER_STATUS)
+        self.assert_no_error(response)
+
+        response = cast(api_typing.S2C.InformServerStatus, response)
+
+        self.assertEqual(response['device_status'], 'connected_ready')
         self.assertEqual(response['device_session_id'], self.server.device_handler.get_comm_session_id())
 
         self.assertIn(response['device_datalogging_status']['datalogger_state'], ['standby', 'unavailable'])
@@ -98,12 +107,11 @@ class TestInterractWithDeviceNoThrottling(ScrutinyIntegrationTestWithTestSFD1):
 
     def test_read_status(self):
         self.send_request({
-            'cmd': API.Command.Client2Api.GET_SERVER_STATUS,
+            'cmd': API.Command.Client2Api.GET_DEVICE_INFO,
         })
-        response = self.wait_and_load_response(cmd=API.Command.Api2Client.INFORM_SERVER_STATUS)
+        response = self.wait_and_load_response(cmd=API.Command.Api2Client.GET_DEVICE_INFO)
         self.assert_no_error(response)
 
-        response = cast(api_typing.S2C.InformServerStatus, response)
+        response = cast(api_typing.S2C.GetDeviceInfo, response)
 
-        self.assertEqual(response['device_status'], 'connected_ready')
         self.assertEqual(response['device_info']['max_bitrate_bps'], None)

--- a/test/server/test_device_handler.py
+++ b/test/server/test_device_handler.py
@@ -87,10 +87,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
         self.disconnect_callback_called = False
         self.disconnect_was_clean = False
         timeout = 2
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_successful = False
         disconnect_sent = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
@@ -114,12 +114,13 @@ class TestDeviceHandler(ScrutinyUnitTest):
     def test_establish_full_connection_and_hold(self):
         setup_timeout = 2
         hold_time = 10
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_successful = False
         hold_time_set = False
         timeout = setup_timeout
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
             self.assertEqual(self.device_handler.get_comm_error_count(), 0)
@@ -130,7 +131,7 @@ class TestDeviceHandler(ScrutinyUnitTest):
                 if hold_time_set == False:
                     hold_time_set = True
                     timeout = hold_time
-                    t1 = time.time()
+                    t1 = time.monotonic()
             else:
                 self.assertIsNone(self.device_handler.get_comm_session_id())
 
@@ -142,10 +143,11 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
     def test_read_correct_params(self):
         timeout = 3
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_successful = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
 
@@ -203,11 +205,12 @@ class TestDeviceHandler(ScrutinyUnitTest):
     def test_auto_disconnect_if_comm_interrupted(self):
         self.device_handler.expect_no_timeout = False
         timeout = 5     # Should take about 2.5 sec to disconnect With heartbeat at every 2 sec
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_completed = False
         connection_lost = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
 
@@ -227,11 +230,12 @@ class TestDeviceHandler(ScrutinyUnitTest):
         # Should behave exactly the same as test_auto_disconnect_if_comm_interrupted
         self.device_handler.expect_no_timeout = False
         timeout = 5     # Should take about 2.5 sec to disconnect With heartbeat at every 2 sec
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_completed = False
         connection_lost = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
 
@@ -249,12 +253,13 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
     def test_auto_disconnect_and_reconnect_on_broken_link(self):
         timeout = 10     # Should take about 2.5 sec to disconnect With heartbeat at every 2 sec
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_completed = False
         connection_lost = False
         connection_recovered = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
 
@@ -285,16 +290,17 @@ class TestDeviceHandler(ScrutinyUnitTest):
         self.emulated_device.max_bitrate_bps = target_bitrate
         self.device_handler.set_operating_mode(DeviceHandler.OperatingMode.Test_CheckThrottling)
         connect_time = None
-        t1 = time.time()
-        while time.time() - t1 < timeout:
+        t1 = time.monotonic()
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             status = self.device_handler.get_connection_status()
             if status == DeviceHandler.ConnectionStatus.CONNECTED_READY and connect_time is None:
                 self.device_handler.reset_bitrate_monitor()
-                connect_time = time.time()
+                connect_time = time.monotonic()
                 self.assertTrue(self.device_handler.is_throttling_enabled())
                 self.assertEqual(self.device_handler.get_throttling_bitrate(), self.emulated_device.max_bitrate_bps)
-                t1 = time.time()
+                t1 = time.monotonic()
                 timeout = measurement_time
 
         self.assertIsNotNone(connect_time)
@@ -340,15 +346,16 @@ class TestDeviceHandler(ScrutinyUnitTest):
         test_round_to_do = 5
         setup_timeout = 2
         hold_timeout = 5
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_successful = False
         timeout = setup_timeout
         time_margin = 0.1
 
         round_completed = 0
         state = 'init_memory'
-        while time.time() - t1 < timeout and round_completed < test_round_to_do:
+        while time.monotonic() - t1 < timeout and round_completed < test_round_to_do:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             status = self.device_handler.get_connection_status()
             self.assertEqual(self.device_handler.get_comm_error_count(), 0)
 
@@ -365,12 +372,12 @@ class TestDeviceHandler(ScrutinyUnitTest):
                     self.emulated_device.write_memory(0x10000, struct.pack('<f', 3.1415926))
                     self.emulated_device.write_memory(0x10010, struct.pack('<q', 0x123456789abcdef))
                     self.emulated_device.write_memory(0x10020, struct.pack('<b', 1))
-                    init_memory_time = time.time()
+                    init_memory_timestamp = time.time()
                     state = 'read_memory'
 
                 elif state == 'read_memory':
-                    value_updated = (vfloat32.get_value_change_timestamp() > init_memory_time + time_margin) and (vint64.get_value_change_timestamp() >
-                                                                                                                  init_memory_time + time_margin) and (vbool.get_value_change_timestamp() > init_memory_time + time_margin)
+                    value_updated = (vfloat32.get_value_change_timestamp() > init_memory_timestamp + time_margin) and (vint64.get_value_change_timestamp() >
+                                                                                                                  init_memory_timestamp + time_margin) and (vbool.get_value_change_timestamp() > init_memory_timestamp + time_margin)
 
                     if value_updated:
                         self.assertEqual(vfloat32.get_value(), d2f(3.1415926), 'round=%d' % round_completed)
@@ -381,20 +388,20 @@ class TestDeviceHandler(ScrutinyUnitTest):
                         self.datastore.update_target_value(vint64, 0x1122334455667788, no_callback)
                         self.datastore.update_target_value(vbool, False, no_callback)
 
-                        write_time = time.time()
+                        write_timestamp = time.time()
                         state = 'write_memory'
 
-                    elif time.time() - init_memory_time > 1:
+                    elif time.time() - init_memory_timestamp > 1:
                         raise Exception('Value did not update')
 
                 elif state == 'write_memory':
                     value_updated = True
                     value_updated = value_updated and (vfloat32.get_last_target_update_timestamp() is not None) and (
-                        vfloat32.get_last_target_update_timestamp() > write_time)
+                        vfloat32.get_last_target_update_timestamp() > write_timestamp)
                     value_updated = value_updated and (vint64.get_last_target_update_timestamp() is not None) and (
-                        vint64.get_last_target_update_timestamp() > write_time)
+                        vint64.get_last_target_update_timestamp() > write_timestamp)
                     value_updated = value_updated and (vbool.get_last_target_update_timestamp() is not None) and (
-                        vbool.get_last_target_update_timestamp() > write_time)
+                        vbool.get_last_target_update_timestamp() > write_timestamp)
 
                     if value_updated:
                         self.assertEqual(vfloat32.get_value(), d2f(2.7), 'round=%d' % round_completed)
@@ -408,7 +415,7 @@ class TestDeviceHandler(ScrutinyUnitTest):
                         round_completed += 1
                         state = 'init_memory'
 
-                    elif time.time() - write_time > 1:
+                    elif time.monotonic() - write_timestamp > 1:
                         raise Exception('Value not written')
 
             # Make sure we don't disconnect
@@ -428,13 +435,14 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
         timeout = setup_timeout
         round_completed = 0
-        t1 = time.time()
+        t1 = time.monotonic()
         all_entries = []
         state = 'wait_for_connection'
         connected = False
 
-        while time.time() - t1 < timeout and round_completed < test_round_to_do:
+        while time.monotonic() - t1 < timeout and round_completed < test_round_to_do:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
 
             status = self.device_handler.get_connection_status()
             self.assertEqual(self.device_handler.get_comm_error_count(), 0)
@@ -550,10 +558,11 @@ class TestDeviceHandler(ScrutinyUnitTest):
         self.assertFalse(self.emulated_device.is_datalogging_enabled(), "Datalogging is disabled on emulated device.")
 
         timeout = 4
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_completed = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
             if status == DeviceHandler.ConnectionStatus.CONNECTED_READY and connection_completed == False:
@@ -565,8 +574,8 @@ class TestDeviceHandler(ScrutinyUnitTest):
         self.assertFalse(device_info.supported_feature_map['datalogging'])
         self.assertFalse(self.device_handler.datalogging_poller.is_enabled())
 
-        t1 = time.time()
-        while time.time() - t1 < 0.5:
+        t1 = time.monotonic()
+        while time.monotonic() - t1 < 0.5:
             self.device_handler.process()   # Keep processing to see if datalogging feature will do something (it should not)
 
         self.assertIsNone(self.device_handler.get_datalogging_setup())   # Should never be set
@@ -604,10 +613,11 @@ class TestDeviceHandler(ScrutinyUnitTest):
             logger.debug("[iteration=%d] Wait for connection" % iteration)
             # First we wait on connection to be ready with the device
             timeout = 4
-            t1 = time.time()
+            t1 = time.monotonic()
             connection_completed = False
-            while time.time() - t1 < timeout:
+            while time.monotonic() - t1 < timeout:
                 self.device_handler.process()
+                self.emulated_device.wake_if_sleep()    # speed up
                 time.sleep(0.01)
                 status = self.device_handler.get_connection_status()
                 if status == DeviceHandler.ConnectionStatus.CONNECTED_READY and connection_completed == False:
@@ -615,9 +625,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
                     break
 
             timeout = 2
-            t1 = time.time()
-            while time.time() - t1 < timeout:
+            t1 = time.monotonic()
+            while time.monotonic() - t1 < timeout:
                 self.device_handler.process()
+                self.emulated_device.wake_if_sleep()    # speed up
                 time.sleep(0.01)
                 if self.device_handler.get_datalogger_state() is not None:
                     break
@@ -635,10 +646,11 @@ class TestDeviceHandler(ScrutinyUnitTest):
             # Next wait for datalogging poller to retrieve the configuration of the datalogging feature
             logger.debug("[iteration=%d] Wait for setup" % iteration)
             timeout = 2
-            t1 = time.time()
+            t1 = time.monotonic()
             datalogging_setup = None
-            while time.time() - t1 < timeout:
+            while time.monotonic() - t1 < timeout:
                 self.device_handler.process()
+                self.emulated_device.wake_if_sleep()    # speed up
                 datalogging_setup = self.device_handler.get_datalogging_setup()
                 if datalogging_setup is not None and self.device_handler.is_ready_for_datalogging_acquisition_request():  # Expect setup to be read
                     break
@@ -652,6 +664,7 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
             # Make sure nothing happens unless somebody require an acquisition
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             time.sleep(0.1)
             self.device_handler.process()
             if iteration == 0:
@@ -687,9 +700,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
                 self.device_handler.cancel_datalogging_acquisition()
                 self.assertTrue(self.device_handler.datalogging_cancel_in_progress())
                 timeout = 1
-                t1 = time.time()
-                while self.device_handler.datalogging_cancel_in_progress() and time.time() - t1 < timeout:
+                t1 = time.monotonic()
+                while self.device_handler.datalogging_cancel_in_progress() and time.monotonic() - t1 < timeout:
                     self.device_handler.process()
+                    self.emulated_device.wake_if_sleep()    # speed up
                 self.assertFalse(self.device_handler.datalogging_cancel_in_progress())
 
                 self.device_handler.request_datalogging_acquisition(loop_id, config, self.acquisition_complete_callback)
@@ -701,9 +715,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
             # Make sure it is received and that the device is waiting for the trigger to happen
             logger.debug("[iteration=%d] Wait for armed" % iteration)
             timeout = 2
-            t1 = time.time()
-            while time.time() - t1 < timeout:
+            t1 = time.monotonic()
+            while time.monotonic() - t1 < timeout:
                 self.device_handler.process()
+                self.emulated_device.wake_if_sleep()    # speed up
                 if self.device_handler.get_datalogger_state() == device_datalogging.DataloggerState.ARMED:
                     break
 
@@ -718,9 +733,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
                 self.device_handler.cancel_datalogging_acquisition()
                 self.assertTrue(self.device_handler.datalogging_cancel_in_progress())
                 timeout = 2
-                t1 = time.time()
-                while self.device_handler.datalogging_cancel_in_progress() and time.time() - t1 < timeout:
+                t1 = time.monotonic()
+                while self.device_handler.datalogging_cancel_in_progress() and time.monotonic() - t1 < timeout:
                     self.device_handler.process()
+                    self.emulated_device.wake_if_sleep()    # speed up
                 self.assertFalse(self.device_handler.datalogging_cancel_in_progress())
 
                 self.device_handler.request_datalogging_acquisition(loop_id, config, self.acquisition_complete_callback)
@@ -731,8 +747,8 @@ class TestDeviceHandler(ScrutinyUnitTest):
                 continue    #
 
             # Make sure it stays it the same state if the trigger never happens
-            t1 = time.time()
-            while time.time() - t1 < 0.5:
+            t1 = time.monotonic()
+            while time.monotonic() - t1 < 0.5:
                 self.device_handler.process()
                 time.sleep(0.05)
 
@@ -746,9 +762,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
             logger.debug("[iteration=%d] Wait for acquisition complete" % iteration)
             timeout = 2
-            t1 = time.time()
-            while time.time() - t1 < timeout:
+            t1 = time.monotonic()
+            while time.monotonic() - t1 < timeout:
                 self.device_handler.process()
+                self.emulated_device.wake_if_sleep()    # speed up
                 time.sleep(0.01)
                 if self.acquisition_complete_callback_called:
                     break
@@ -794,9 +811,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
     def test_user_command(self):
         timeout = 3
-        t1 = time.time()
-        while time.time() - t1 < timeout:
+        t1 = time.monotonic()
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             status = self.device_handler.get_connection_status()
             if status == DeviceHandler.ConnectionStatus.CONNECTED_READY:
                 break
@@ -832,8 +850,8 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
         self.device_handler.request_user_command(1, bytes([1, 2, 3, 4]), callback)
 
-        t1 = time.time()
-        while time.time() - t1 < timeout:
+        t1 = time.monotonic()
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
             if retval.called:
                 break
@@ -846,8 +864,8 @@ class TestDeviceHandler(ScrutinyUnitTest):
         retval.clear()
         self.device_handler.request_user_command(0xFF, bytes([1, 2, 3, 4]), callback)
 
-        t1 = time.time()
-        while time.time() - t1 < timeout:
+        t1 = time.monotonic()
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
             if retval.called:
                 break
@@ -863,9 +881,10 @@ class TestDeviceHandler(ScrutinyUnitTest):
 
         timeout = self.device_handler.config['response_timeout'] + 2
         self.device_handler.expect_no_timeout = False
-        t1 = time.time()
-        while time.time() - t1 < timeout:
+        t1 = time.monotonic()
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
+            self.emulated_device.wake_if_sleep()    # speed up
             if retval.called:
                 break
         self.assertTrue(retval.called)
@@ -923,9 +942,9 @@ class TestDeviceHandlerMultipleLink(ScrutinyUnitTest):
 
         # Should behave exactly the same as test_auto_disconnect_if_comm_interrupted
         timeout = 5     # Should take about 2.5 sec to disconnect With heartbeat at every 2 sec
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_completed = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()
@@ -944,9 +963,9 @@ class TestDeviceHandlerMultipleLink(ScrutinyUnitTest):
         self.assertNotEqual(self.device_handler.get_connection_status(), DeviceHandler.ConnectionStatus.CONNECTED_READY)
 
         timeout = 5     # Should take about 2.5 sec to disconnect With heartbeat at every 2 sec
-        t1 = time.time()
+        t1 = time.monotonic()
         connection_completed = False
-        while time.time() - t1 < timeout:
+        while time.monotonic() - t1 < timeout:
             self.device_handler.process()
             time.sleep(0.01)
             status = self.device_handler.get_connection_status()


### PR DESCRIPTION
- device info not included in inform_server_status API call
- Device info can be read with new API call get_device_info
- Datalogging capabilities are read once when connecting to a device, ensuring they stay available for the lifetime of the session