### PR TITLE
Improve testing of API parser + Better hadnling of SFD metadata

### DIFF
--- a/scrutiny/cli/commands/list_datalog.py
+++ b/scrutiny/cli/commands/list_datalog.py
@@ -84,7 +84,12 @@ class ListDatalog(BaseCommand):
 
             if SFDStorage.is_installed(acq.firmware_id):
                 firmware_meta = SFDStorage.get_metadata(acq.firmware_id)
-                entry.firmware_fullname = "%s (%s V%s)" % (acq.firmware_id, firmware_meta['project_name'], firmware_meta['version'])
+                project_name = "<No name>"
+                if firmware_meta.project_name is not None:
+                    project_name = firmware_meta.project_name
+                    if firmware_meta.version is not None:
+                        project_name += " V%s" % firmware_meta.version
+                entry.firmware_fullname = f"{acq.firmware_id} ({project_name})"
             sizes.update(entry)
             all_entries.append(entry)
 

--- a/scrutiny/cli/commands/make_metadata.py
+++ b/scrutiny/cli/commands/make_metadata.py
@@ -40,7 +40,7 @@ class MakeMetadata(BaseCommand):
 
     def run(self) -> Optional[int]:
         import scrutiny
-        from scrutiny.core.firmware_description import MetadataType
+        from scrutiny.core.firmware_description import MetadataTypedDict
         args = self.parser.parse_args(self.args)
 
         if args.output is None:
@@ -56,7 +56,7 @@ class MakeMetadata(BaseCommand):
             self.getLogger().warning("Could not find the scrutiny version")
             scrutiny_version = '0.0.0'
 
-        metadata: MetadataType = {
+        metadata: MetadataTypedDict = {
             'project_name': args.project_name,
             'author': args.author,
             'version': args.version,

--- a/scrutiny/core/sfd_storage_manager.py
+++ b/scrutiny/core/sfd_storage_manager.py
@@ -9,7 +9,7 @@
 __all__ = ['SFDStorageManager']
 
 import os
-from scrutiny.core.firmware_description import FirmwareDescription, MetadataType
+from scrutiny.core.firmware_description import FirmwareDescription, SFDMetadata
 import logging
 import os
 import re
@@ -133,7 +133,7 @@ class SFDStorageManager:
 
         return FirmwareDescription(filename)
 
-    def get_metadata(self, firmwareid: str) -> MetadataType:
+    def get_metadata(self, firmwareid: str) -> SFDMetadata:
         """Reads only the metadata from the Firmware DEscription file in the global storage identified by the given ID"""
         storage = self.get_storage_dir()
         firmwareid = self.clean_firmware_id(firmwareid)
@@ -141,8 +141,8 @@ class SFDStorageManager:
         return FirmwareDescription.read_metadata_from_sfd_file(filename)
 
     def list(self) -> List[str]:
-        """Returns a list of firmware ID installed in the global storage"""
         thelist = []
+        """Returns a list of firmware ID installed in the global storage"""
         if os.path.isdir(self.get_storage_dir()):
             for filename in os.listdir(self.get_storage_dir()):   # file name is firmware ID
                 if os.path.isfile(os.path.join(self.get_storage_dir(), filename)) and self.is_valid_firmware_id(filename):

--- a/scrutiny/gui/core/server_manager.py
+++ b/scrutiny/gui/core/server_manager.py
@@ -892,6 +892,7 @@ class ServerManager:
         else:
             if error is not None:
                 self._logger.error(f"Failed to download the SFD details: {error}")
+                tools.log_exception(self._logger, error)
 
         if valid:
             assert loaded_sfd is not None

--- a/scrutiny/sdk/definitions.py
+++ b/scrutiny/sdk/definitions.py
@@ -8,9 +8,9 @@
 
 import enum
 from dataclasses import dataclass
-from datetime import datetime
 from scrutiny.core.basic_types import MemoryRegion, EmbeddedDataType, WatchableType
 from scrutiny.core.embedded_enum import EmbeddedEnum
+from scrutiny.core.firmware_description import SFDMetadata, SFDGenerationInfo
 from scrutiny.tools import validation
 import abc
 from binascii import hexlify
@@ -310,33 +310,6 @@ class DeviceInfo:
     datalogging_capabilities:Optional[DataloggingCapabilities]
     """Contains the device datalogging capabilites. ``None`` if datalogging is not supported"""
 
-
-@dataclass(frozen=True)
-class SFDGenerationInfo:
-    """(Immutable struct) Metadata relative to the generation of the SFD"""
-
-    timestamp: Optional[datetime]
-    """Date/time at which the SFD has been created ``None`` if not available"""
-    python_version: Optional[str]
-    """Python version with which the SFD has been created ``None`` if not available"""
-    scrutiny_version: Optional[str]
-    """Scrutiny version with which the SFD has been created ``None`` if not available"""
-    system_type: Optional[str]
-    """Type of system on which the SFD has been created. Value given by Python `platform.system()`. ``None`` if not available"""
-
-
-@dataclass(frozen=True)
-class SFDMetadata:
-    """(Immutable struct) All the metadata associated with a Scrutiny Firmware Description"""
-
-    project_name: Optional[str]
-    """Name of the project. ``None`` if not available"""
-    author: Optional[str]
-    """The author of this firmware. ``None`` if not available"""
-    version: Optional[str]
-    """The version string of this firmware. ``None`` if not available"""
-    generation_info: Optional[SFDGenerationInfo]
-    """Metadata regarding the creation environment of the SFD file. ``None`` if not available"""
 
 
 @dataclass(frozen=True)

--- a/scrutiny/server/api/API.py
+++ b/scrutiny/server/api/API.py
@@ -696,7 +696,7 @@ class API:
         firmware_id_list = SFDStorage.list()
         metadata_dict = {}
         for firmware_id in firmware_id_list:
-            metadata_dict[firmware_id] = SFDStorage.get_metadata(firmware_id)
+            metadata_dict[firmware_id] = SFDStorage.get_metadata(firmware_id).to_dict()
 
         response: api_typing.S2C.GetInstalledSFD = {
             'cmd': self.Command.Api2Client.GET_INSTALLED_SFD_RESPONSE,
@@ -716,7 +716,7 @@ class API:
             'cmd': self.Command.Api2Client.GET_LOADED_SFD_RESPONSE,
             'reqid': self.get_req_id(req),
             'firmware_id': sfd.get_firmware_id_ascii() if sfd is not None else None,
-            'metadata' : sfd.get_metadata() if sfd is not None else None
+            'metadata' : sfd.get_metadata().to_dict() if sfd is not None else None
         }
 
         self.client_handler.send(ClientHandlerMessage(conn_id=conn_id, obj=response))
@@ -1474,7 +1474,7 @@ class API:
             acq = DataloggingStorage.read(reference_id)
             firmware_metadata: Optional[api_typing.SFDMetadata] = None
             if SFDStorage.is_installed(acq.firmware_id):
-                firmware_metadata = SFDStorage.get_metadata(acq.firmware_id)
+                firmware_metadata = SFDStorage.get_metadata(acq.firmware_id).to_dict()
             acquisitions.append({
                 'firmware_id': acq.firmware_id,
                 'name': acq.name,

--- a/scrutiny/server/api/typing.py
+++ b/scrutiny/server/api/typing.py
@@ -17,7 +17,7 @@ import scrutiny.server.device.links.udp_link
 
 WatchableType = Literal['alias', 'var', 'rpv']
 # Mapping between app type and API type.
-SFDMetadata = scrutiny.core.firmware_description.MetadataType
+SFDMetadata = scrutiny.core.firmware_description.MetadataTypedDict
 SerialLinkConfig = scrutiny.server.device.links.serial_link.SerialConfig
 UdpLinkConfig = scrutiny.server.device.links.udp_link.UdpConfig
 RttLinkConfig = scrutiny.server.device.links.rtt_link.RttConfig

--- a/scrutiny/server/datalogging/datalogging_manager.py
+++ b/scrutiny/server/datalogging/datalogging_manager.py
@@ -137,10 +137,10 @@ class DataloggingManager:
                 firmware_name: Optional[str] = None
                 if SFDStorage.is_installed(device_info.device_id):
                     sfd_metadata = SFDStorage.get_metadata(device_info.device_id)
-                    if 'project_name' in sfd_metadata:
-                        firmware_name = sfd_metadata["project_name"]
-                        if 'version' in sfd_metadata:
-                            firmware_name += " V%s" % sfd_metadata["version"]
+                    if sfd_metadata.project_name is not None:
+                        firmware_name = sfd_metadata.project_name
+                        if sfd_metadata.version is not None:
+                            firmware_name += " V%s" % sfd_metadata.version
                 # Crate the acquisition
                 acquisition = DataloggingAcquisition(
                     name=self.active_request.api_request.name,

--- a/scrutiny/tools/typing.py
+++ b/scrutiny/tools/typing.py
@@ -8,7 +8,7 @@
 
 __all__ = ['Self', 'List', 'Set', 'Dict', 'Union', 'Optional', 'Any', 'cast', 'Iterable', 
            'Sequence', 'Callable', 'TypedDict', 'Literal',
-           'TypeVar', 'ParamSpec', 'TYPE_CHECKING', 'Generator', 'Tuple', 'TypeAlias', 'Type']
+           'TypeVar', 'ParamSpec', 'TYPE_CHECKING', 'Generator', 'Tuple', 'TypeAlias', 'Type', 'IO']
 
 import sys
 
@@ -41,5 +41,6 @@ from typing import (
     Generator,
     Tuple,
     TypeAlias,
-    Type
+    Type,
+    IO
     )

--- a/test/gui/fake_sdk_client.py
+++ b/test/gui/fake_sdk_client.py
@@ -462,7 +462,7 @@ class FakeSDKClient(tools.UnitTestStub):
                             python_version="aaa",
                             scrutiny_version="bbb",
                             system_type="ccc",
-                            timestamp=datetime.now().timestamp(),
+                            timestamp=datetime.now(),
                         )
                     )
                 )

--- a/test/integration/test_datalogging_integration.py
+++ b/test/integration/test_datalogging_integration.py
@@ -271,7 +271,7 @@ class TestDataloggingIntegration(ScrutinyIntegrationTestWithTestSFD1):
                                 self.assertIsNone(acq_summary['firmware_metadata'])
                             else:   # emulated device firmware ID is cahnged at the end of the loop so it matches the SFD
                                 self.assertIsNotNone(acq_summary['firmware_metadata'])
-                                self.assertEqual(acq_summary['firmware_metadata'], self.sfd.get_metadata())
+                                self.assertEqual(acq_summary['firmware_metadata'], self.sfd.get_metadata().to_dict())
                             break
 
                     self.assertTrue(found)
@@ -295,7 +295,7 @@ class TestDataloggingIntegration(ScrutinyIntegrationTestWithTestSFD1):
                     if session_iteration == 0:
                         self.assertIsNone(response['firmware_name'])
                     else:
-                        expected_firmware_name = '%s V%s' % (self.sfd.get_metadata()['project_name'], self.sfd.get_metadata()['version'])
+                        expected_firmware_name = '%s V%s' % (self.sfd.get_metadata().project_name, self.sfd.get_metadata().version)
                         self.assertEqual(response['firmware_name'], expected_firmware_name)
 
                     # Check that all signals has the same number of points, including x axis

--- a/test/integration/test_interract_with_device.py
+++ b/test/integration/test_interract_with_device.py
@@ -106,15 +106,15 @@ class TestInterractWithDevice(ScrutinyIntegrationTestWithTestSFD1):
         loaded_sfd = self.server.sfd_handler.get_loaded_sfd()
         self.assertEqual(response['firmware_id'], loaded_sfd.get_firmware_id_ascii())
 
-        self.assertEqual(response['metadata']['author'], loaded_sfd.metadata['author'])
-        self.assertEqual(response['metadata']['project_name'], loaded_sfd.metadata['project_name'])
-        self.assertEqual(response['metadata']['version'], loaded_sfd.metadata['version'])
+        self.assertEqual(response['metadata']['author'], loaded_sfd.metadata.author)
+        self.assertEqual(response['metadata']['project_name'], loaded_sfd.metadata.project_name)
+        self.assertEqual(response['metadata']['version'], loaded_sfd.metadata.version)
         self.assertEqual(response['metadata']['generation_info']['python_version'],
-                         loaded_sfd.metadata['generation_info']['python_version'])
+                         loaded_sfd.metadata.generation_info.python_version)
         self.assertEqual(response['metadata']['generation_info']['scrutiny_version'],
-                         loaded_sfd.metadata['generation_info']['scrutiny_version'])
-        self.assertEqual(response['metadata']['generation_info']['system_type'], loaded_sfd.metadata['generation_info']['system_type'])
-        self.assertEqual(response['metadata']['generation_info']['time'], loaded_sfd.metadata['generation_info']['time'])
+                         loaded_sfd.metadata.generation_info.scrutiny_version)
+        self.assertEqual(response['metadata']['generation_info']['system_type'], loaded_sfd.metadata.generation_info.system_type)
+        self.assertEqual(response['metadata']['generation_info']['time'], loaded_sfd.metadata.generation_info.timestamp.timestamp())
 
 class TestInterractWithDeviceNoThrottling(ScrutinyIntegrationTestWithTestSFD1):
 

--- a/test/sdk/test_client.py
+++ b/test/sdk/test_client.py
@@ -737,15 +737,7 @@ class TestClient(ScrutinyUnitTest):
 
         sfd = FirmwareDescription(get_artifact('test_sfd_1.sfd'))
         self.assertEqual(server_sfd.firmware_id, sfd.get_firmware_id_ascii())
-        self.assertEqual(server_sfd.metadata.author, sfd.metadata['author'])
-        self.assertEqual(server_sfd.metadata.project_name, sfd.metadata['project_name'])
-        self.assertEqual(server_sfd.metadata.version, sfd.metadata['version'])
-
-        self.assertEqual(server_sfd.metadata.generation_info.python_version, sfd.metadata['generation_info']['python_version'])
-        self.assertEqual(server_sfd.metadata.generation_info.scrutiny_version, sfd.metadata['generation_info']['scrutiny_version'])
-        self.assertEqual(server_sfd.metadata.generation_info.system_type, sfd.metadata['generation_info']['system_type'])
-        self.assertEqual(server_sfd.metadata.generation_info.timestamp, datetime.fromtimestamp(sfd.metadata['generation_info']['time']))
-
+        self.assertEqual(server_sfd.metadata, sfd.metadata)
 
     def test_get_device_info(self):
         # Make sure we can read the status of the server correctly
@@ -1403,22 +1395,11 @@ class TestClient(ScrutinyUnitTest):
             installed2 = installed[sfd2.get_firmware_id_ascii()]
 
             self.assertEqual(installed1.firmware_id, sfd1.get_firmware_id_ascii())
-            self.assertEqual(installed1.metadata.author, sfd1.get_metadata()['author'])
-            self.assertEqual(installed1.metadata.project_name, sfd1.get_metadata()['project_name'])
-            self.assertEqual(installed1.metadata.version, sfd1.get_metadata()['version'])
-            self.assertEqual(installed1.metadata.generation_info.python_version, sfd1.get_metadata()['generation_info']['python_version'])
-            self.assertEqual(installed1.metadata.generation_info.scrutiny_version, sfd1.get_metadata()['generation_info']['scrutiny_version'])
-            self.assertEqual(installed1.metadata.generation_info.system_type, sfd1.get_metadata()['generation_info']['system_type'])
-            self.assertEqual(installed1.metadata.generation_info.timestamp, datetime.fromtimestamp(sfd1.get_metadata()['generation_info']['time']))
-
+            self.assertEqual(installed1.metadata, sfd1.get_metadata())
+          
             self.assertEqual(installed2.firmware_id, sfd2.get_firmware_id_ascii())
-            self.assertEqual(installed2.metadata.author, sfd2.get_metadata()['author'])
-            self.assertEqual(installed2.metadata.project_name, sfd2.get_metadata()['project_name'])
-            self.assertEqual(installed2.metadata.version, sfd2.get_metadata()['version'])
-            self.assertEqual(installed2.metadata.generation_info.python_version, sfd2.get_metadata()['generation_info']['python_version'])
-            self.assertEqual(installed2.metadata.generation_info.scrutiny_version, sfd2.get_metadata()['generation_info']['scrutiny_version'])
-            self.assertEqual(installed2.metadata.generation_info.system_type, sfd2.get_metadata()['generation_info']['system_type'])
-            self.assertEqual(installed2.metadata.generation_info.timestamp, datetime.fromtimestamp(sfd2.get_metadata()['generation_info']['time']))
+            self.assertEqual(installed2.metadata, sfd2.get_metadata())
+           
 
     def test_simple_request_response_timeout(self):
         with SFDStorage.use_temp_folder():

--- a/test/server/test_api.py
+++ b/test/server/test_api.py
@@ -1031,7 +1031,7 @@ class TestAPI(ScrutinyUnitTest):
                 self.assertIn(installed_firmware_id, response['sfd_list'])
                 gotten_metadata = response['sfd_list'][installed_firmware_id]
                 real_metadata = SFDStorage.get_metadata(installed_firmware_id)
-                self.assertEqual(real_metadata, gotten_metadata)
+                self.assertEqual(real_metadata.to_dict(), gotten_metadata)
 
             SFDStorage.uninstall(sfd1.get_firmware_id_ascii())
             SFDStorage.uninstall(sfd2.get_firmware_id_ascii())
@@ -1064,7 +1064,7 @@ class TestAPI(ScrutinyUnitTest):
             self.assertIn('metadata', response)
             self.assertIn('firmware_id', response)
             self.assertEqual(response['firmware_id'], sfd1.get_firmware_id_ascii())
-            self.assertEqual(response['metadata'], sfd1.get_metadata() )
+            self.assertEqual(response['metadata'], sfd1.get_metadata().to_dict() )
 
             # load #2
             req = {
@@ -1086,7 +1086,7 @@ class TestAPI(ScrutinyUnitTest):
             self.assertIn('firmware_id', response)
             self.assertIn('metadata', response)
             self.assertEqual(response['firmware_id'], sfd2.get_firmware_id_ascii())
-            self.assertEqual(response['metadata'], sfd2.get_metadata())
+            self.assertEqual(response['metadata'], sfd2.get_metadata().to_dict())
 
             SFDStorage.uninstall(sfd1.get_firmware_id_ascii())
             SFDStorage.uninstall(sfd2.get_firmware_id_ascii())
@@ -1870,19 +1870,19 @@ class TestAPI(ScrutinyUnitTest):
                 self.assertEqual(response['acquisitions'][0]['reference_id'], 'refid1')
                 self.assertEqual(response['acquisitions'][0]['timestamp'], int(acq1.acq_time.timestamp()))
                 self.assertEqual(response['acquisitions'][0]['name'], 'foo')
-                self.assertEqual(response['acquisitions'][0]['firmware_metadata'], sfd1.get_metadata())
+                self.assertEqual(response['acquisitions'][0]['firmware_metadata'], sfd1.get_metadata().to_dict())
 
                 self.assertEqual(response['acquisitions'][1]['firmware_id'], sfd1.get_firmware_id_ascii())
                 self.assertEqual(response['acquisitions'][1]['reference_id'], 'refid2')
                 self.assertEqual(response['acquisitions'][1]['timestamp'], int(acq2.acq_time.timestamp()))
                 self.assertEqual(response['acquisitions'][1]['name'], 'bar')
-                self.assertEqual(response['acquisitions'][1]['firmware_metadata'], sfd1.get_metadata())
+                self.assertEqual(response['acquisitions'][1]['firmware_metadata'], sfd1.get_metadata().to_dict())
 
                 self.assertEqual(response['acquisitions'][2]['firmware_id'], sfd2.get_firmware_id_ascii())
                 self.assertEqual(response['acquisitions'][2]['reference_id'], 'refid3')
                 self.assertEqual(response['acquisitions'][2]['timestamp'], int(acq3.acq_time.timestamp()))
                 self.assertEqual(response['acquisitions'][2]['name'], 'baz')
-                self.assertEqual(response['acquisitions'][2]['firmware_metadata'], sfd2.get_metadata())
+                self.assertEqual(response['acquisitions'][2]['firmware_metadata'], sfd2.get_metadata().to_dict())
 
                 self.assertEqual(response['acquisitions'][3]['firmware_id'], "unknown_sfd")
                 self.assertEqual(response['acquisitions'][3]['reference_id'], 'refid4')
@@ -1935,13 +1935,13 @@ class TestAPI(ScrutinyUnitTest):
                 self.assertEqual(response['acquisitions'][0]['reference_id'], 'refid1')
                 self.assertEqual(response['acquisitions'][0]['timestamp'], int(acq1.acq_time.timestamp()))
                 self.assertEqual(response['acquisitions'][0]['name'], 'foo')
-                self.assertEqual(response['acquisitions'][0]['firmware_metadata'], sfd1.get_metadata())
+                self.assertEqual(response['acquisitions'][0]['firmware_metadata'], sfd1.get_metadata().to_dict())
 
                 self.assertEqual(response['acquisitions'][1]['firmware_id'], sfd1.get_firmware_id_ascii())
                 self.assertEqual(response['acquisitions'][1]['reference_id'], 'refid2')
                 self.assertEqual(response['acquisitions'][1]['timestamp'], int(acq2.acq_time.timestamp()))
                 self.assertEqual(response['acquisitions'][1]['name'], 'bar')
-                self.assertEqual(response['acquisitions'][1]['firmware_metadata'], sfd1.get_metadata())
+                self.assertEqual(response['acquisitions'][1]['firmware_metadata'], sfd1.get_metadata().to_dict())
 
                 req: api_typing.C2S.ListDataloggingAcquisitions = {
                     'cmd': 'list_datalogging_acquisitions',
@@ -2028,7 +2028,7 @@ class TestAPI(ScrutinyUnitTest):
                 self.assertEqual(response['acquisitions'][0]['reference_id'], 'refid2')
                 self.assertEqual(response['acquisitions'][0]['timestamp'], int(acq2.acq_time.timestamp()))
                 self.assertEqual(response['acquisitions'][0]['name'], 'bar')
-                self.assertEqual(response['acquisitions'][0]['firmware_metadata'], sfd1.get_metadata())
+                self.assertEqual(response['acquisitions'][0]['firmware_metadata'], sfd1.get_metadata().to_dict())
 
 
     def test_update_datalogging_acquisition(self):


### PR DESCRIPTION
- Fully test the API parser module
- SFD metadata is not stored as dict anymore. Use a core structure shared by the server and the sdk.